### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,11 @@ Non-obvious caveats:
 
 - **Required env vars (the app 500s without them).** `app/layout.tsx` calls
   `new URL(process.env.SITE_URL!)` at module load, so the site throws `ERR_INVALID_URL` on every
-  page if `SITE_URL` is unset. `.env*` is gitignored and not committed, so create a local
-  `.env.local` at the repo root before running anything:
+  page if `SITE_URL` is unset. The vars are `SITE_URL`, `SITE_TITLE`, `SITE_DESCRIPTION`,
+  `SITE_AUTHOR`, `SITE_AUTHOR_TWITTER_ID`. In Cursor Cloud these are provided as injected secrets,
+  so no setup is needed — just confirm they're present (`echo $SITE_URL`). If they are ever missing
+  (e.g. running outside Cloud), create a local `.env.local` at the repo root instead (`.env*` is
+  gitignored and not committed; real production values live in Vercel):
 
   ```
   SITE_URL=http://localhost:3000
@@ -24,8 +27,10 @@ Non-obvious caveats:
   SITE_AUTHOR_TWITTER_ID=curtismunson
   ```
 
-  These are non-secret site config values; the dev placeholders above are sufficient for local dev,
-  build, lint, and typecheck. (Real production values are set in Vercel.)
+- **tmux + injected secrets gotcha.** The `tmux` server captures its environment when it first
+  starts. If you add/change secrets after a tmux server is already running, new sessions will NOT
+  see them and the dev server will 500 on `SITE_URL`. Run `tmux -f /exec-daemon/tmux.portal.conf
+  kill-server` and start a fresh session so it inherits the current environment.
 
 - **Use `pnpm dev:watch`, not `pnpm dev`, when adding/renaming Markdown.** `lib/markdown.tsx`
   caches the `content/` directory listing in module memory and only busts it when `tmp/reload-trigger.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a personal blog built with Next.js 16 (App Router, Turbopack) + React 19, written in
+TypeScript and styled with Tailwind v4. Content is plain Markdown in `content/` (`YYYY-MM-DD.slug.md`,
+or `DRAFT.slug.md` for drafts). There is no database or backend service — it is effectively a
+static site. Package manager is `pnpm` (see `packageManager` in `package.json`). Standard
+commands live in `package.json` scripts (`dev`, `dev:watch`, `build`, `start`, `lint`, `typecheck`,
+`format`).
+
+Non-obvious caveats:
+
+- **Required env vars (the app 500s without them).** `app/layout.tsx` calls
+  `new URL(process.env.SITE_URL!)` at module load, so the site throws `ERR_INVALID_URL` on every
+  page if `SITE_URL` is unset. `.env*` is gitignored and not committed, so create a local
+  `.env.local` at the repo root before running anything:
+
+  ```
+  SITE_URL=http://localhost:3000
+  SITE_TITLE=John Munson's Blog
+  SITE_DESCRIPTION=A technical blog about software engineering, AI, and developer tooling.
+  SITE_AUTHOR=John Munson
+  SITE_AUTHOR_TWITTER_ID=curtismunson
+  ```
+
+  These are non-secret site config values; the dev placeholders above are sufficient for local dev,
+  build, lint, and typecheck. (Real production values are set in Vercel.)
+
+- **Use `pnpm dev:watch`, not `pnpm dev`, when adding/renaming Markdown.** `lib/markdown.tsx`
+  caches the `content/` directory listing in module memory and only busts it when `tmp/reload-trigger.ts`
+  changes. Plain `pnpm dev` will return a 500 (`Post not found for slug: ...`) for newly added posts
+  until the server restarts. `pnpm dev:watch` runs `scripts/watch-content.ts` alongside the dev
+  server, which rewrites the trigger file on `.md` changes so new/edited posts hot-reload. Editing an
+  existing post's body hot-reloads under plain `pnpm dev` too; it's specifically the file list (new
+  files / renames) that needs the watcher.
+
+- **Node version.** `package.json` `engines` requests Node `^24`. The default cloud Node is v22, which
+  satisfies Next.js 16 and runs install/lint/typecheck/build/dev cleanly — pnpm only prints a
+  non-blocking "Unsupported engine" warning. No action needed unless you specifically want to silence it.
+
+- The dev server binds `http://localhost:3000`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the local development environment for this Next.js blog. The only committed change is a new `AGENTS.md` capturing durable, non-obvious setup caveats for future agents/developers.

## What was verified

- `pnpm install` — dependencies install cleanly (Node 22, pnpm 10.26.0)
- `pnpm lint` — 0 errors (4 pre-existing warnings)
- `pnpm typecheck` — passes
- `pnpm build` — production build succeeds
- `pnpm dev:watch` — dev server runs at `http://localhost:3000`; homepage, post pages, `rss.xml`, and `sitemap.xml` all return 200

Verified end to end both with a local `.env.local` and, after the site config secrets were added in Cursor, using the injected secrets directly (no `.env.local`).

## Hello-world task

Created a temporary Markdown post and confirmed it rendered end to end in the browser (homepage list → post page), then removed it (no junk content committed).

## Key non-obvious findings (documented in AGENTS.md)

- The app 500s without the site config env vars (`SITE_URL` is read at module load in `app/layout.tsx`). In Cursor Cloud these are provided as injected secrets; otherwise a local gitignored `.env.local` is required.
- New/renamed Markdown files are not picked up by plain `pnpm dev` (the content dir listing is cached in module memory); use `pnpm dev:watch`.
- tmux captures its environment at server start — if secrets are added after a tmux server is running, kill the server so new sessions inherit them.

[blog_dev_env_walkthrough.mp4](https://cursor.com/agents/bc-248906ea-9777-46fa-a1a6-7069b092fb9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dev_env_walkthrough.mp4)

[Homepage with post list](https://cursor.com/agents/bc-248906ea-9777-46fa-a1a6-7069b092fb9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_post_list.webp)
[Rendered post page](https://cursor.com/agents/bc-248906ea-9777-46fa-a1a6-7069b092fb9d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_post_rendered.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-248906ea-9777-46fa-a1a6-7069b092fb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-248906ea-9777-46fa-a1a6-7069b092fb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

