### PR TITLE
Add blog post table of contents

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getPostData, getAllPosts } from "../../lib/markdown"
 import { formatDate, toNoonISO8601 } from "@/lib/utils"
 import { DateText } from "@/components/date-text"
 import { PencilLineIcon } from "@/components/pencil-line-icon"
+import { TableOfContents } from "@/components/table-of-contents"
 import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from "@/lib/generate-og-image"
 
 export async function generateMetadata({
@@ -69,21 +70,26 @@ export default async function Post({
     //   - larger top margin
     //   - bold font weight
     <div className="prose-p:my-4 prose-h2:text-base prose-h2:leading-[1.75] prose-h2:mt-8 prose-h2:mb-4 prose-h2:font-bold">
-      <Link href="/" className="text-sm">
-        {"<<"} back
-      </Link>
-      <article>
-        <div className="not-prose flex items-center gap-2 mt-9 mb-0">
-          <h1 className="font-bold text-xl">{postData.title}</h1>
-          {postData.isDraft && (
-            <span title="This is a draft post">
-              <PencilLineIcon className="size-5 text-red-500 shrink-0" />
-            </span>
-          )}
+      <div className="lg:grid lg:w-[calc(70ch+16rem)] lg:max-w-[calc(100vw-2rem)] lg:grid-cols-[minmax(0,70ch)_13rem] lg:gap-12">
+        <div>
+          <Link href="/" className="text-sm">
+            {"<<"} back
+          </Link>
+          <article>
+            <div className="not-prose flex items-center gap-2 mt-9 mb-0">
+              <h1 className="font-bold text-xl">{postData.title}</h1>
+              {postData.isDraft && (
+                <span title="This is a draft post">
+                  <PencilLineIcon className="size-5 text-red-500 shrink-0" />
+                </span>
+              )}
+            </div>
+            <DateText>{formatDate(postData.date)}</DateText>
+            <div className="mt-8">{postData.content}</div>
+          </article>
         </div>
-        <DateText>{formatDate(postData.date)}</DateText>
-        <div className="mt-8">{postData.content}</div>
-      </article>
+        <TableOfContents items={postData.tableOfContents} />
+      </div>
     </div>
   )
 }

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -65,8 +65,8 @@ export default async function Post({
   const postData = await getPostData(slug)
 
   return (
-    // Keep paragraphs the same, but reduce the top/bottom margins slightly.
-    // Then, change h2 styles to exactly match paragraphs, except...
+    // Keeps paragraphs the same, but reduces the top/bottom margins slightly.
+    // Also, changes h2 styles to exactly match paragraphs, except...
     //   - larger top margin
     //   - bold font weight
     <div className="prose-p:my-4 prose-h2:text-base prose-h2:leading-[1.75] prose-h2:mt-8 prose-h2:mb-4 prose-h2:font-bold">

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -70,25 +70,25 @@ export default async function Post({
     //   - larger top margin
     //   - bold font weight
     <div className="prose-p:my-4 prose-h2:text-base prose-h2:leading-[1.75] prose-h2:mt-8 prose-h2:mb-4 prose-h2:font-bold">
-      <div className="lg:grid lg:w-[calc(70ch+16rem)] lg:max-w-[calc(100vw-2rem)] lg:grid-cols-[minmax(0,70ch)_13rem] lg:gap-12">
-        <div>
-          <Link href="/" className="text-sm">
-            {"<<"} back
-          </Link>
-          <article>
-            <div className="not-prose flex items-center gap-2 mt-9 mb-0">
-              <h1 className="font-bold text-xl">{postData.title}</h1>
-              {postData.isDraft && (
-                <span title="This is a draft post">
-                  <PencilLineIcon className="size-5 text-red-500 shrink-0" />
-                </span>
-              )}
-            </div>
-            <DateText>{formatDate(postData.date)}</DateText>
-            <div className="mt-8">{postData.content}</div>
-          </article>
-        </div>
-        <TableOfContents items={postData.tableOfContents} />
+      <div className="lg:w-[calc(70ch+16rem)] lg:max-w-[calc(100vw-2rem)]">
+        <Link href="/" className="text-sm">
+          {"<<"} back
+        </Link>
+        <article>
+          <div className="not-prose flex items-center gap-2 mt-9 mb-0 lg:w-[70ch]">
+            <h1 className="font-bold text-xl">{postData.title}</h1>
+            {postData.isDraft && (
+              <span title="This is a draft post">
+                <PencilLineIcon className="size-5 text-red-500 shrink-0" />
+              </span>
+            )}
+          </div>
+          <DateText>{formatDate(postData.date)}</DateText>
+          <div className="mt-8 lg:grid lg:grid-cols-[minmax(0,70ch)_13rem] lg:gap-12">
+            <div>{postData.content}</div>
+            <TableOfContents items={postData.tableOfContents} />
+          </div>
+        </article>
       </div>
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,10 @@
   }
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
@@ -48,6 +52,7 @@ body {
 /* Styles for autolinked headings */
 .with-heading-anchor {
   position: relative;
+  scroll-margin-top: 1rem;
 }
 .heading-anchor {
   display: inline-flex;

--- a/components/table-of-contents.tsx
+++ b/components/table-of-contents.tsx
@@ -1,0 +1,40 @@
+import type { TableOfContentsItem } from "@/lib/markdown"
+import { cn } from "@/lib/utils"
+
+type TableOfContentsProps = {
+  items: TableOfContentsItem[]
+}
+
+export function TableOfContents({ items }: TableOfContentsProps) {
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="not-prose hidden lg:block">
+      <nav
+        aria-label="Table of contents"
+        className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto border-l border-gray-200 pl-4 text-sm dark:border-gray-800"
+      >
+        <h2 className="mb-3 font-mono text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          On this page
+        </h2>
+        <ol className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={cn(
+                  "block text-gray-600 no-underline transition-colors hover:text-foreground dark:text-gray-400 dark:hover:text-foreground",
+                  item.depth > 2 && "pl-3",
+                )}
+              >
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </aside>
+  )
+}

--- a/components/table-of-contents.tsx
+++ b/components/table-of-contents.tsx
@@ -11,11 +11,8 @@ export function TableOfContents({ items }: TableOfContentsProps) {
   }
 
   return (
-    <aside className="not-prose hidden lg:mt-[3.75rem] lg:block">
-      <nav
-        aria-label="Table of contents"
-        className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto border-l border-gray-200 pl-4 text-sm dark:border-gray-800"
-      >
+    <aside className="not-prose hidden border-l border-gray-200 pl-4 text-sm dark:border-gray-800 lg:sticky lg:top-4 lg:mt-16 lg:block lg:max-h-[calc(100vh-2rem)] lg:self-start lg:overflow-y-auto">
+      <nav aria-label="Table of contents">
         <h2 className="mb-3 font-mono text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
           On this page
         </h2>

--- a/components/table-of-contents.tsx
+++ b/components/table-of-contents.tsx
@@ -11,7 +11,7 @@ export function TableOfContents({ items }: TableOfContentsProps) {
   }
 
   return (
-    <aside className="not-prose hidden lg:mt-8 lg:block">
+    <aside className="not-prose hidden lg:mt-[3.75rem] lg:block">
       <nav
         aria-label="Table of contents"
         className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto border-l border-gray-200 pl-4 text-sm dark:border-gray-800"

--- a/components/table-of-contents.tsx
+++ b/components/table-of-contents.tsx
@@ -11,7 +11,7 @@ export function TableOfContents({ items }: TableOfContentsProps) {
   }
 
   return (
-    <aside className="not-prose hidden lg:block">
+    <aside className="not-prose hidden lg:mt-8 lg:block">
       <nav
         aria-label="Table of contents"
         className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto border-l border-gray-200 pl-4 text-sm dark:border-gray-800"

--- a/lib/markdown.tsx
+++ b/lib/markdown.tsx
@@ -208,7 +208,7 @@ function getNodeText(node: HastNode): string {
 }
 
 const collectTableOfContents: Plugin<[], HastNode> = () => {
-  return (tree, file) => {
+  return (tree: HastNode, file: VFile) => {
     const tableOfContents: TableOfContentsItem[] = []
 
     visit(tree, "element", (node) => {

--- a/lib/markdown.tsx
+++ b/lib/markdown.tsx
@@ -151,7 +151,7 @@ type PostData = {
   isDraft: boolean
 }
 
-type PostMeta = Omit<PostData, "content">
+type PostMeta = Omit<PostData, "content" | "tableOfContents">
 
 export type TableOfContentsItem = {
   id: string

--- a/lib/markdown.tsx
+++ b/lib/markdown.tsx
@@ -147,10 +147,17 @@ type PostData = {
   title: string
   description: string
   content: React.ReactNode
+  tableOfContents: TableOfContentsItem[]
   isDraft: boolean
 }
 
 type PostMeta = Omit<PostData, "content">
+
+export type TableOfContentsItem = {
+  id: string
+  title: string
+  depth: number
+}
 
 type Frontmatter = {
   title: string
@@ -184,6 +191,51 @@ const markdownComponents = {
   },
 }
 
+type HastNode = {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+  value?: unknown
+}
+
+function getNodeText(node: HastNode): string {
+  if (node.type === "text" && typeof node.value === "string") {
+    return node.value
+  }
+
+  return node.children?.map(getNodeText).join("") ?? ""
+}
+
+const collectTableOfContents: Plugin<[], HastNode> = () => {
+  return (tree, file) => {
+    const tableOfContents: TableOfContentsItem[] = []
+
+    visit(tree, "element", (node) => {
+      const heading = node as HastNode
+
+      if (!heading.tagName || !/^h[1-6]$/.test(heading.tagName)) {
+        return
+      }
+
+      const id = heading.properties?.id
+      const title = getNodeText(heading).trim()
+
+      if (typeof id !== "string" || title.length === 0) {
+        return
+      }
+
+      tableOfContents.push({
+        id,
+        title,
+        depth: Number.parseInt(heading.tagName.slice(1), 10),
+      })
+    })
+
+    file.data.tableOfContents = tableOfContents
+  }
+}
+
 function createMarkdownProcessor() {
   return (
     unified()
@@ -207,6 +259,7 @@ function createMarkdownProcessor() {
         },
       })
       .use(rehypeSlug)
+      .use(collectTableOfContents)
       .use(rehypeAutolinkHeadings, {
         behavior: "append",
         content: [
@@ -262,6 +315,8 @@ export const getPostData = cache(async (slug: string): Promise<PostData> => {
     title,
     description,
     content: file.result as React.ReactNode,
+    tableOfContents:
+      (file.data.tableOfContents as TableOfContentsItem[] | undefined) ?? [],
     isDraft,
   }
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an auto-generated table of contents for blog posts using the existing markdown heading IDs.
- Render the table of contents as a sticky desktop-only right column aligned with the first visible rendered post heading.
- Enable smooth scrolling to generated heading anchors.

### Walkthrough
[blog_toc_content_aligned_and_sticky.mp4](https://cursor.com/agents/bc-122a762a-6b4a-4de6-abcb-0ad00c0495f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_toc_content_aligned_and_sticky.mp4)

### Testing
- `pnpm lint` passed with existing warnings in `lib/generate-og-image.tsx` and a Node version warning from the local environment.
- `pnpm build` passed and prerendered blog routes; output also reported an existing `whitespace-pre-wrap` unknown utility warning.
- `pnpm typecheck` passed after the successful Next build generated route/type files.
- Manual browser test confirmed the ToC title aligns with the first rendered post heading on initial load and the full ToC remains sticky while scrolling.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-122a762a-6b4a-4de6-abcb-0ad00c0495f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-122a762a-6b4a-4de6-abcb-0ad00c0495f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

